### PR TITLE
Clarify careers URL

### DIFF
--- a/src/_includes/layouts/career.html
+++ b/src/_includes/layouts/career.html
@@ -12,7 +12,7 @@
     <dt>Closes</dt>
     <dd>{{ endDate | dateFilter }}</dd>
   </dl>
-  <a class="button primary" href="{{ url }}">Apply for this role</a>
+  <a class="button primary" href="{{ applicationUrl }} target="_blank" rel="noopener noreferrer"">Apply for this role</a>
 </div>
 {% endset %}
 

--- a/src/careers/full-stack-software-developer.md
+++ b/src/careers/full-stack-software-developer.md
@@ -1,14 +1,15 @@
 ---
 title: Full Stack Software Developer
+applicationUrl: https://app.beapplied.com/apply/jsia4ficmj
 startDate: 2021-02-22T05:53:04.604Z
 endDate: 2021-03-09T05:53:04.632Z
 location: Australia, Sydney or Canberra (preferred)
 salary: $85,000 – $90,000
-url: full-stack-software-developer
 summary: We are looking for someone driven to join our tech team and use their
   passion, experience and skills in tech to help us in our fight for a
   prosperous future free from climate change and inequality.
 ---
+
 ## About Future Super
 
 At Future Super, we’re making \[sh]it happen and changing the way super is done. By giving people a chance to invest their life savings in companies that don’t harm the planet, we’re showing the power super has to change the world!
@@ -17,7 +18,7 @@ We strongly encourage applications from Aboriginal and/or Torres Strait Islander
 
 ## About the team
 
-Our Tech Team is made up of a group of individuals who are passionate about technology and using their skills in the fight for a prosperous future free from climate change and inequality! They do so by supporting the business with a reliable IT infrastructure and developing tools that connect our members to the power of their money.  
+Our Tech Team is made up of a group of individuals who are passionate about technology and using their skills in the fight for a prosperous future free from climate change and inequality! They do so by supporting the business with a reliable IT infrastructure and developing tools that connect our members to the power of their money.
 
 The latest project for the team has been rebuilding the system supporting our growing members base. We are looking for someone driven to join our ambitious team and is ready to think outside the box about the ways technology can help people. The Tech Team works fast, collaboratively, and celebrates their wins as a united team.
 
@@ -27,47 +28,47 @@ Our team has a relatively flat and collaborative structure. The team reports to 
 
 ## What you’ll be doing
 
-* Working in a unified, agile environment with our engineering team to create and improve software that you can be proud of
-* Taking responsibility for documentation, code quality and testing, while ensuring the team is taking a best practice approach
-* Working independently while also helping the team to succeed, assisting them with planning, estimation, design, development, integration, qualification and testing
-* Learning new technologies and growing professionally as the demands of the role change
-* Provide and receive honest feedback, allowing the team to continually improve how they work together
-* Using your creativity to overcome technical challenges
-* Travelling between Canberra and Sydney on a regular (monthly) basis to collaborate with other teams across the business
+- Working in a unified, agile environment with our engineering team to create and improve software that you can be proud of
+- Taking responsibility for documentation, code quality and testing, while ensuring the team is taking a best practice approach
+- Working independently while also helping the team to succeed, assisting them with planning, estimation, design, development, integration, qualification and testing
+- Learning new technologies and growing professionally as the demands of the role change
+- Provide and receive honest feedback, allowing the team to continually improve how they work together
+- Using your creativity to overcome technical challenges
+- Travelling between Canberra and Sydney on a regular (monthly) basis to collaborate with other teams across the business
 
 ## We are looking for someone who has
 
-* PHP/Laravel software development experience (outside of university based projects), coupled with a decent understanding of the software development cycle
-* A relevant tertiary degree (Bachelor of Software Engineering, Information Technology, or equivalent)
-* 2-3 years relevant experience in developing software and/or web applications
-* Familiarity with relational databases
-* Exposure to frameworks and ORMs
-* Client side coding experience (HTML, css, Javascript, VueJS)
-* Experience implementing code quality assurance best practices
-* Passion about coding and an interest in growing their career in this space
-* High level verbal and written communication skills
-* Experience utilising Git version control tool
-* Experience working as part of a team, and enjoys taking a collaborative approach to their work
-* Availability to travel to Sydney and Canberra
+- PHP/Laravel software development experience (outside of university based projects), coupled with a decent understanding of the software development cycle
+- A relevant tertiary degree (Bachelor of Software Engineering, Information Technology, or equivalent)
+- 2-3 years relevant experience in developing software and/or web applications
+- Familiarity with relational databases
+- Exposure to frameworks and ORMs
+- Client side coding experience (HTML, css, Javascript, VueJS)
+- Experience implementing code quality assurance best practices
+- Passion about coding and an interest in growing their career in this space
+- High level verbal and written communication skills
+- Experience utilising Git version control tool
+- Experience working as part of a team, and enjoys taking a collaborative approach to their work
+- Availability to travel to Sydney and Canberra
 
 ## It would also be great if you have
 
-* Script coding experience (bash, Python)
-* Familiarity with Linux system (or at least MacOs, from Catalina onward)
-* Operative knowledge of NoSql systems (Redis)
-* Knowledge and experience of cloud environment (GCP or similar)  
-* Experience working in an agile environment (as a Scrum Master)
-* Experience in the superannuation industry
-* Experience working in a small high-growth startup
+- Script coding experience (bash, Python)
+- Familiarity with Linux system (or at least MacOs, from Catalina onward)
+- Operative knowledge of NoSql systems (Redis)
+- Knowledge and experience of cloud environment (GCP or similar)
+- Experience working in an agile environment (as a Scrum Master)
+- Experience in the superannuation industry
+- Experience working in a small high-growth startup
 
 Don't meet all the criteria listed here? Don’t worry! Providing you have the right foundational experience and certain qualifications, we encourage you to apply. We are happy to train and develop people into roles, if we think they’re a great fit for our team and show promise.
 
 ## You'll love working here with
 
-* A purpose-oriented organisation, spending your days working on making this world a better place! The more we grow, the bigger the impact we are making on climate action and equality
-* A proud B-Corp organisation that cares about what how we behave on the inside
-* Team lunches, drinks and company-wide events
-* 14 weeks’ paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you’re in the office) and membership to Bicycle NSW  (or your State’s equivalent) as part of our sustainable transport policy
-* Future Super is an equal opportunity employer – we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point, but it’s still true!)
+- A purpose-oriented organisation, spending your days working on making this world a better place! The more we grow, the bigger the impact we are making on climate action and equality
+- A proud B-Corp organisation that cares about what how we behave on the inside
+- Team lunches, drinks and company-wide events
+- 14 weeks’ paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you’re in the office) and membership to Bicycle NSW  (or your State’s equivalent) as part of our sustainable transport policy
+- Future Super is an equal opportunity employer – we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point, but it’s still true!)
 
 ‍

--- a/src/careers/senior-investment-risk-manager.md
+++ b/src/careers/senior-investment-risk-manager.md
@@ -1,6 +1,6 @@
 ---
 title: "Senior Investment Risk Manager"
-url: "https://app.beapplied.com/apply/h8kzxvzeon"
+applicationUrl: "https://app.beapplied.com/apply/h8kzxvzeon"
 location: "Sydney"
 salary: "$165,000 – $175,000 + super"
 startDate: "2021-01-01"

--- a/src/careers/social-media.producer.md
+++ b/src/careers/social-media.producer.md
@@ -1,6 +1,6 @@
 ---
 title: "Social Media Producer"
-url: "https://app.beapplied.com/apply/g5q8gvo7up"
+applicationUrl: "https://app.beapplied.com/apply/g5q8gvo7up"
 location: "Sydney (preferred)"
 salary: "$160,000 – $70,000 + 10.5% super"
 startDate: "2021-01-18"


### PR DESCRIPTION
The external job application URL threw me off when manually filling out the latest job ad. I misunderstood `url` to be a manual 'slugification' of the page itself, not its external job application.

I've clarified this in the frontmatter and updated the CMS too.