### PR TITLE
fix: language change

### DIFF
--- a/src/_includes/partials/acknowledgement-of-country-footer.html
+++ b/src/_includes/partials/acknowledgement-of-country-footer.html
@@ -7,9 +7,14 @@
       </div>
       <div class="statement grid">
         <div class="content">
-          <p>Future Super acknowledges the <span class="traditional-custodians">Traditional Custodians</span> of the lands on which we operate and pay our respects to Elders, past, present and emerging. We recognise the enduring relationship First Nations peoples have with Country and that sovereignty was never ceded.</p>
+          <p>Future Super acknowledges the <span class="traditional-custodians">Traditional Custodians</span> of the
+            lands on which we operate and pay our respects to Elders, past, present and emerging. We recognise the
+            enduring relationship Aboriginal and/or Torres Strait Islander peoples have with Country and that
+            sovereignty was never ceded.</p>
 
-          <p>We stand for a future that promotes justice for First Nations peoples and profoundly respects and acknowledges First Nations perspectives, culture, language and history.</p>
+          <p>We stand for a future that promotes justice for Aboriginal and/or Torres Strait Islander peoples and
+            profoundly respects and
+            acknowledges First Nations perspectives, culture, language and history.</p>
         </div>
       </div>
     </article>

--- a/src/_includes/partials/acknowledgement-of-country-header.html
+++ b/src/_includes/partials/acknowledgement-of-country-header.html
@@ -3,7 +3,10 @@
     <article>
       <div class="statement grid">
         <div class="content">
-          <p>Future Super acknowledges the <span class="traditional-custodians">Traditional Custodians</span> of the lands on which we operate and pay our respects to Elders, past, present and emerging. We recognise the enduring relationship First Nations peoples have with Country and that sovereignty was never ceded.</p>
+          <p>Future Super acknowledges the <span class="traditional-custodians">Traditional Custodians</span> of the
+            lands on which we operate and pay our respects to Elders, past, present and emerging. We recognise the
+            enduring relationship Aboriginal and/or Torres Strait Islander peoples have with Country and that
+            sovereignty was never ceded.</p>
         </div>
       </div>
     </article>

--- a/src/careers/senior-investment-risk-manager.md
+++ b/src/careers/senior-investment-risk-manager.md
@@ -12,7 +12,7 @@ summary: "We are looking for someone to join our passionate team as the Senior I
 
 At Future Super, we're changing the way super is done. By giving people a chance to invest their life savings in companies that don't harm the planet, and instead directing those investments into companies and projects that make the world better, we're proving to our industry that doing good can effect meaningful change in so many ways.
 
-We encourage applications from First Nations peoples, people with disability, people from diverse cultural and linguistic backgrounds, mature age workers and lesbian, gay, bisexual, transgender, intersex, etc. (LGBTI+) people. Seriously. The problems we face are complex and the more diversity of experiences we can bring to the table the better our solutions become.
+We encourage applications from Aboriginal and/or Torres Strait Islander peoples, people with disability, people from diverse cultural and linguistic backgrounds, mature age workers and lesbian, gay, bisexual, transgender, intersex, etc. (LGBTI+) people. Seriously. The problems we face are complex and the more diversity of experiences we can bring to the table the better our solutions become.
 
 ## About this role
 
@@ -22,34 +22,34 @@ We are looking for someone enthusiastic about establishing close relationships w
 
 ## Key responsibilities
 
-- Maintain and drive the Investment Governance Framework and associated policies, procedures and documentation. This includes working with Future Super's internal risk management system (Folio);
-- Ensure the Investment Governance Framework remains up to date with APRA guidelines and market practice;
-- Produce periodic risk reporting on investment risks (including compiling reports and providing analysis and commentary on performance and risk attribution, compliance breach reporting, liquidity analysis);
-- Support the Chair of the Investment Committee through the provision of risk analysis and commentary separate to the investment management team; attending Investment Committee meetings;
-- Monitor whether the investment management team's investment decisions are made in compliance with the Investment Governance Framework, Investment Strategy (incorporating the Investment Policy Statement), disclosure documents and Investment Management Agreements;
-- Constructively challenge the investment management team on assumptions, calculations and proposals they put forward;
-- Coordinate the annual stress testing and performance objectives of the Funds;
-- Monitor the investment management team's approach to ensuring all investments are valued as accurately as possible, and that these valuations are reflected in the unit price;
-- Monitor whether the Impact Team's work is in compliance with PDS, the Screening and Impact Framework and the Investment Strategy;
-- Coordinate with internal audit, the assurance program of compliance and effectiveness of controls, including unit pricing across each investment option.
+-   Maintain and drive the Investment Governance Framework and associated policies, procedures and documentation. This includes working with Future Super's internal risk management system (Folio);
+-   Ensure the Investment Governance Framework remains up to date with APRA guidelines and market practice;
+-   Produce periodic risk reporting on investment risks (including compiling reports and providing analysis and commentary on performance and risk attribution, compliance breach reporting, liquidity analysis);
+-   Support the Chair of the Investment Committee through the provision of risk analysis and commentary separate to the investment management team; attending Investment Committee meetings;
+-   Monitor whether the investment management team's investment decisions are made in compliance with the Investment Governance Framework, Investment Strategy (incorporating the Investment Policy Statement), disclosure documents and Investment Management Agreements;
+-   Constructively challenge the investment management team on assumptions, calculations and proposals they put forward;
+-   Coordinate the annual stress testing and performance objectives of the Funds;
+-   Monitor the investment management team's approach to ensuring all investments are valued as accurately as possible, and that these valuations are reflected in the unit price;
+-   Monitor whether the Impact Team's work is in compliance with PDS, the Screening and Impact Framework and the Investment Strategy;
+-   Coordinate with internal audit, the assurance program of compliance and effectiveness of controls, including unit pricing across each investment option.
 
 ## Skills and experience
 
 You will thrive in this role if your passion, strengths, and approach to work are aligned with the description above. Other useful skills and experience include:
 
-- Values-aligned, someone who cares about making the world a better place for everyone;
-- Someone with a lot of integrity, who is committed to ethical decision making;
-- Strong leadership skills with the ability to operate at both tactical and strategic levels;
-- Excellent communication skills, with the ability to influence;
-- Strong organisational skills, takes delivering on deadlines and sticking to schedules seriously;
-- Stakeholder management skills, gets lots of energy out of building strong working relationships and collaborates well in a team environment;
-- 5+ years experience in asset management consulting or related;
-- Tertiary qualifications in mathematics based degrees such as econometrics or finance.
+-   Values-aligned, someone who cares about making the world a better place for everyone;
+-   Someone with a lot of integrity, who is committed to ethical decision making;
+-   Strong leadership skills with the ability to operate at both tactical and strategic levels;
+-   Excellent communication skills, with the ability to influence;
+-   Strong organisational skills, takes delivering on deadlines and sticking to schedules seriously;
+-   Stakeholder management skills, gets lots of energy out of building strong working relationships and collaborates well in a team environment;
+-   5+ years experience in asset management consulting or related;
+-   Tertiary qualifications in mathematics based degrees such as econometrics or finance.
 
 ## You'll love working here with
 
-- A purpose-oriented organisation, spend your days working on making this world a better place! The more we grow, the bigger the impact we are making on climate change and inequality.
-- A close-knit team that embraces learning, openness and transparency - focusing on delivering quality outcomes and enabling the company vision.
-- Heaps of flexibility to fit work into your life (not your life around our work) and the opportunity to work with your manager to define what that looks like for you now and in the future.
-- 14 weeks' paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you're in the office) and membership to Bicycle NSW as part of our sustainable transport policy.
-- Future Super is an equal opportunity employer -- we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point but it is still true!)
+-   A purpose-oriented organisation, spend your days working on making this world a better place! The more we grow, the bigger the impact we are making on climate change and inequality.
+-   A close-knit team that embraces learning, openness and transparency - focusing on delivering quality outcomes and enabling the company vision.
+-   Heaps of flexibility to fit work into your life (not your life around our work) and the opportunity to work with your manager to define what that looks like for you now and in the future.
+-   14 weeks' paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you're in the office) and membership to Bicycle NSW as part of our sustainable transport policy.
+-   Future Super is an equal opportunity employer -- we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point but it is still true!)

--- a/src/careers/social-media.producer.md
+++ b/src/careers/social-media.producer.md
@@ -6,8 +6,8 @@ location: Sydney (preferred)
 salary: $60,000 – $70,000 + 10.5% super
 applicationUrl: https://app.beapplied.com/apply/g5q8gvo7up
 summary: With ambitious targets and a passionate membership base, we’re on the
-  hunt for a Social Media Producer to be the voice of Future Super on social
-  digital platforms.
+    hunt for a Social Media Producer to be the voice of Future Super on social
+    digital platforms.
 ---
 
 ## About Future Super
@@ -16,28 +16,28 @@ At Future Super, we're making [sh]it happen and changing the way super is done. 
 
 With ambitious targets and a passionate membership base, we're on the hunt for a Social Media Producer to be the voice of Future Super on social digital platforms.
 
-We strongly encourage applications from First Nations peoples, people with disability, people from diverse cultural and linguistic backgrounds, mature age workers and lesbian, gay, bisexual, transgender, intersex, etc. (LGBTI+) people. Seriously, the problems we face are complex and the more diversity of experiences we can bring to the table, the better our solutions become.
+We strongly encourage applications from Aboriginal and/or Torres Strait Islander peoples, people with disability, people from diverse cultural and linguistic backgrounds, mature age workers and lesbian, gay, bisexual, transgender, intersex, etc. (LGBTI+) people. Seriously, the problems we face are complex and the more diversity of experiences we can bring to the table, the better our solutions become.
 
 ## You'll love this job if
 
-- Social media is your place of community. You are constantly finding to new ways to learn from others and gather like-minded people on Instagram, Facebook, Twitter and TikTok
-- You have an aptitude for trying things out as a means to learn, you're not that risk adverse or hurt when something doesn't work, constantly learning fuels your fire
-- You find superannuation opaque and frustrating, if you had the chance to revolutionize the industry to be better for people, you would
-- You love talking, working within a team and moving quickly. You get bored easily and constantly want to push what's possible
-- You love to have varied conversations on socials but can also see when someone's getting on their high horse for no reason so don't need to reply
+-   Social media is your place of community. You are constantly finding to new ways to learn from others and gather like-minded people on Instagram, Facebook, Twitter and TikTok
+-   You have an aptitude for trying things out as a means to learn, you're not that risk adverse or hurt when something doesn't work, constantly learning fuels your fire
+-   You find superannuation opaque and frustrating, if you had the chance to revolutionize the industry to be better for people, you would
+-   You love talking, working within a team and moving quickly. You get bored easily and constantly want to push what's possible
+-   You love to have varied conversations on socials but can also see when someone's getting on their high horse for no reason so don't need to reply
 
 ## We're looking for someone who
 
-- Holds a distinctive written voice that reflects culture and the internet
-- Loves telling stories and creating work that move people emotionally (a dislike for traditional corporate marketing and communication is a must)
-- Has experience gathering information from various resources
-- Is curious to explore all the ways an idea can come to life and eagerness to learn by doing
-- Believes in Future Super's mission and has a passion for moving Australia's money out of fossil-fuels and into renewable energy
+-   Holds a distinctive written voice that reflects culture and the internet
+-   Loves telling stories and creating work that move people emotionally (a dislike for traditional corporate marketing and communication is a must)
+-   Has experience gathering information from various resources
+-   Is curious to explore all the ways an idea can come to life and eagerness to learn by doing
+-   Believes in Future Super's mission and has a passion for moving Australia's money out of fossil-fuels and into renewable energy
 
 ## You'll love working here with
 
-- A team made up of a bunch of people who love their craft, take their work seriously but not themselves, and are always down for exploring a curly question (or seven).
-- Heaps of flexibility to fit work into your life (not your life around our work) and the opportunity to work with your manager to define what that looks like for you now and in the future
-- Team lunches, drinks and company-wide events
-- 14 weeks' paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you're in the office) and membership to Bicycle NSW as part of our sustainable transport policy
-- Future Super is an equal opportunity employer -- we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point, but it's still true!)
+-   A team made up of a bunch of people who love their craft, take their work seriously but not themselves, and are always down for exploring a curly question (or seven).
+-   Heaps of flexibility to fit work into your life (not your life around our work) and the opportunity to work with your manager to define what that looks like for you now and in the future
+-   Team lunches, drinks and company-wide events
+-   14 weeks' paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you're in the office) and membership to Bicycle NSW as part of our sustainable transport policy
+-   Future Super is an equal opportunity employer -- we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point, but it's still true!)


### PR DESCRIPTION
Changed all mentions of “First Nations peoples” to “Aboriginal and/or Torres Strait Islander peoples” on the website as per Lydia's request.