### PR TITLE
Removed duplicate paragraphs in career

### DIFF
--- a/src/_includes/layouts/career.html
+++ b/src/_includes/layouts/career.html
@@ -31,22 +31,6 @@
 
       {{ content | safe }}
 
-      <p>
-        The application will require answering short questions so give yourself time to complete it. Once started, you
-        can save and return to your application before submitting.
-      </p>
-      <p>
-        We use Applied as our de-identified recruitment platform, helping us reduce the risk of unconscious bias in our
-        hiring process. If you are curious to know more about how it works, <a
-          href="/blog/how-de-identified-recruitment-is-improving-the-diversity-of-our-team/">check out this blog
-          post</a> from our Head of Group Strategy, Veronica!
-      </p>
-      <p>
-        Questions? Please reach out to Khaila (Khi), HR Coordinator, at <a
-          href="mailto:careers@futuresuper.com.au?subject={{ title }}">careers@futuresuper.com.au</a>.
-      </p>
-
-
       {{ careerSummaryBlock | safe }}
     </div>
 

--- a/src/careers/social-media-producer.md
+++ b/src/careers/social-media-producer.md
@@ -48,9 +48,3 @@ Don’t tick all the boxes? That’s ok, we like thinking outside the box. We va
 * Team lunches, drinks and company-wide events
 * 14 weeks’ paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you’re in the office) and membership to Bicycle NSW as part of our sustainable transport policy
 * Future Super is an equal opportunity employer – we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point, but it’s still true!)
-
-The application will require answering short questions so give yourself time to complete it. Once started, you can save and return to your application before submitting.
-
-We use Applied as our de-identified recruitment platform, helping us reduce the risk of unconscious bias in our hiring process. If you are curious to know more about how it works, [check out this blog post](https://www.linkedin.com/pulse/how-de-identified-recruitment-improving-diversity-our-veronica/?trackingId=0MnwcX%2BBRQSOTl0oogaIbA%3D%3D) from our Head of Group Strategy, Veronica! 
-
-Questions? Please reach out to Khi, HR Coordinator, at careers@futuresuper.com.au.

--- a/src/careers/social-media-producer.md
+++ b/src/careers/social-media-producer.md
@@ -48,3 +48,9 @@ Don’t tick all the boxes? That’s ok, we like thinking outside the box. We va
 * Team lunches, drinks and company-wide events
 * 14 weeks’ paid parental leave for all genders and a generous parental superannuation package, Employee Assistance Program (EAP), formal training and development with continuous improvement opportunities, a continuous supply of healthy office snacks (if/when you’re in the office) and membership to Bicycle NSW as part of our sustainable transport policy
 * Future Super is an equal opportunity employer – we provide flexible working hours, the option to work from home and a laptop you can use to work remotely (this used to be a more differentiating dot-point, but it’s still true!)
+
+The application will require answering short questions so give yourself time to complete it. Once started, you can save and return to your application before submitting.
+
+We use Applied as our de-identified recruitment platform, helping us reduce the risk of unconscious bias in our hiring process. If you are curious to know more about how it works, [check out this blog post](/blog/how-de-identified-recruitment-is-improving-the-diversity-of-our-team/) from our Head of Group Strategy, Veronica!
+
+Questions? Please reach out to Khi, HR Coordinator, at [careers@futuresuper.com.au](mailto:careers@futuresuper.com.au?subject=Working%20at%20Future%20Super).


### PR DESCRIPTION
Khi and I hardcoded some reused job info on the careers template. We decided to remove that now as it's too easy to forget about (hence causing duplication).